### PR TITLE
Add QA security and operations documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, add-qa-security-ops-docs ]
   pull_request:
 
 jobs:
@@ -26,23 +26,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements-dev.txt
 
-      - name: Lint Python sources and tests
+      - name: Run full validation
         run: |
-          ruff check src tests
-
-      - name: Run test suite with coverage
-        run: |
-          pytest -q --cov=src --cov-report=term-missing
-
-      - name: Run Bandit SAST
-        run: |
-          bandit -r src -ll
-
-      - name: Audit Python dependencies
-        run: |
-          pip-audit -r requirements.txt
-
-      - name: Generate deterministic benchmark summary
-        run: |
-          python -m src.benchmark
-          test -f reports/triage_benchmark_summary.md
+          make validate

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: lint test security audit benchmark validate
+
+lint:
+	ruff check src tests
+
+test:
+	pytest -q --cov=src --cov-report=term-missing
+
+security:
+	bandit -r src -ll
+
+audit:
+	pip-audit -r requirements.txt
+
+benchmark:
+	python -m src.benchmark
+	test -f reports/triage_benchmark_summary.md
+
+validate: lint test security audit benchmark

--- a/VERSION_NOTES.md
+++ b/VERSION_NOTES.md
@@ -1,0 +1,39 @@
+# Version Notes
+
+## v0.1.0 - Portfolio Hardening Release
+
+### Purpose
+
+Initial hardened portfolio release for the Sentinel-AI-AutoTriage project.
+
+### Highlights
+
+- AI-assisted triage workflow.
+- Dry-run-first execution model.
+- Data minimisation layer.
+- Strict parsing and safe fallback behaviour.
+- Deterministic recommendation policy gate.
+- Approval state for sensitive status changes.
+- Metadata-only audit records.
+- Benchmark runner and sample report.
+- CI with linting, tests, coverage, Bandit review and dependency review.
+- CodeQL and Dependabot configuration.
+- Architecture documentation.
+- Threat model.
+- Demo output documentation.
+- Quality and security checklist.
+- Recruiter summary.
+
+### Known limitations
+
+- Portfolio prototype, not unattended production automation.
+- No durable approval queue.
+- No centralised audit store.
+- Small benchmark dataset.
+
+### Future roadmap
+
+- Add configuration schema validation.
+- Add richer benchmark cases.
+- Add central audit export pattern.
+- Add approval workflow integration example.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,50 @@
+# Architecture
+
+## Purpose
+
+Sentinel-AI-AutoTriage demonstrates a safety-first architecture for AI-assisted security operations.
+
+The project is designed to help analysts review incidents faster while keeping authority, write actions and closure decisions behind deterministic controls and human approval.
+
+## High-level flow
+
+```mermaid
+flowchart TD
+    A[Microsoft Sentinel Incidents] --> B[Incident Retrieval]
+    B --> C[Compact Incident Summary]
+    C --> D[Pre-LLM Redaction]
+    D --> E[LLM Provider Boundary]
+    E --> F[Strict JSON Parsing]
+    F --> G[Recommendation Policy Gate]
+    G --> H{Closure Recommended?}
+    H -- No --> I[Dry-Run or Controlled Update]
+    H -- Yes --> J[Human Approval State]
+    J --> I
+    I --> K[Metadata-Only Audit Record]
+```
+
+## Core components
+
+| Component | Purpose |
+|---|---|
+| `src/sentinel_client.py` | Sentinel client boundary. |
+| `src/redaction.py` | Redacts common sensitive-looking values before model use. |
+| `src/llm_client.py` | Handles provider abstraction, parsing and safe fallbacks. |
+| `src/recommendation_policy.py` | Applies deterministic checks before status handling. |
+| `src/approval.py` | Models explicit approval state for sensitive recommendations. |
+| `src/audit.py` | Writes metadata-only audit records. |
+| `src/auto_triage.py` | Orchestrates the triage flow. |
+| `src/benchmark.py` | Runs deterministic safety-pipeline benchmark cases. |
+
+## Design principles
+
+1. Model output is a recommendation, not authority.
+2. Dry-run mode is the default.
+3. Sensitive-looking values are minimised before model use.
+4. Deterministic policy checks gate the recommendation.
+5. Sensitive closure paths require approval.
+6. Audit records avoid raw incident text.
+
+## Operational boundary
+
+This is a portfolio-grade prototype for controlled review and demo use. A production deployment would require tenant-specific access design, durable approval workflow, centralised audit retention, monitoring, alerting, operational runbooks and change-management review.

--- a/docs/demo-output.md
+++ b/docs/demo-output.md
@@ -1,0 +1,44 @@
+# Demo Output
+
+This file documents expected local demo behaviour for portfolio review.
+
+## Run deterministic benchmark
+
+```bash
+python -m src.benchmark
+```
+
+Expected output:
+
+```text
+Wrote reports/triage_benchmark_summary.md
+```
+
+## Expected benchmark summary sections
+
+```text
+# Sentinel AI AutoTriage Benchmark Summary
+## Cases evaluated
+## Recommendation outcomes
+## Policy gate results
+## Approval requirements
+```
+
+## Example analyst-facing interpretation
+
+```text
+Case ID: demo-case-001
+Recommended status: Active
+Classification: NeedsReview
+Policy allowed: true
+Approval required: false
+Update applied: false
+Reason: Dry-run mode is enabled by default.
+```
+
+## Expected safety behaviour
+
+- Dry-run mode should not update Sentinel.
+- Sensitive status changes should require approval.
+- Malformed model output should fall back to safe review.
+- Audit records should not include raw incident text or raw prompt content.

--- a/docs/quality-security-checklist.md
+++ b/docs/quality-security-checklist.md
@@ -1,0 +1,41 @@
+# Quality and Security Checklist
+
+## CI quality gates
+
+Before merge or external presentation, confirm:
+
+- [ ] Ruff linting passes.
+- [ ] Pytest passes.
+- [ ] Coverage step completes.
+- [ ] Bandit review passes.
+- [ ] Dependency review passes.
+- [ ] Benchmark summary is generated.
+- [ ] CodeQL completes successfully.
+
+## Security gates
+
+- [ ] No real tokens or private configuration values are committed.
+- [ ] Dry-run mode remains the default.
+- [ ] Write mode requires explicit configuration.
+- [ ] Sensitive status changes require approval.
+- [ ] Audit records avoid raw incident text and raw prompts.
+- [ ] Redaction layer is tested.
+- [ ] Safe fallback behaviour is tested.
+
+## Operational readiness gates
+
+- [ ] Architecture documentation is present.
+- [ ] Threat model is present.
+- [ ] Demo output is documented.
+- [ ] Recruiter summary is present.
+- [ ] Security policy is present.
+- [ ] README clearly states this is not unattended production automation.
+
+## Future readiness gates
+
+- [ ] Configuration schema validation.
+- [ ] Provider timeout and retry handling.
+- [ ] Durable approval queue.
+- [ ] Centralised audit retention.
+- [ ] Environment-specific access review.
+- [ ] Labelled evaluation dataset.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,57 @@
+# Threat Model
+
+## Scope
+
+This threat model covers the portfolio prototype of Sentinel-AI-AutoTriage.
+
+The project demonstrates how to wrap LLM-assisted incident triage with safety gates, redaction, deterministic policy and auditability.
+
+## Assets
+
+| Asset | Why it matters |
+|---|---|
+| Incident metadata | May contain operational context. |
+| Incident summaries | Input to the model-assistance layer. |
+| Model recommendation | Can influence analyst review. |
+| Approval state | Controls sensitive closure paths. |
+| Audit record | Supports accountability and review. |
+| Configuration | Controls dry-run/write mode and provider settings. |
+
+## Trust boundaries
+
+```mermaid
+flowchart LR
+    S[Sentinel Workspace] --> T[Triage Workflow]
+    T --> R[Redaction Layer]
+    R --> L[LLM Provider Boundary]
+    L --> P[Policy Gate]
+    P --> A[Approval State]
+    A --> U[Update or Dry Run]
+    U --> O[Audit Record]
+```
+
+## Key risks and controls
+
+| Risk | Impact | Existing control | Further hardening |
+|---|---|---|---|
+| Sensitive data sent to model | Privacy or confidentiality issue | Pre-LLM redaction | Add enterprise DLP integration |
+| Model hallucinated status | Incorrect workflow recommendation | Strict parsing and safe fallback | Add labelled evaluation dataset |
+| Unsafe closure recommendation | Premature incident closure | Deterministic policy gate and approval state | Add durable analyst approval queue |
+| Uncontrolled write action | Operational impact | Dry-run default and `AUTO_APPLY_CHANGES` gate | Add scoped service principal policy |
+| Weak audit trail | Poor accountability | Metadata-only audit records | Centralise audit retention and monitoring |
+| Provider outage or malformed output | Workflow instability | Safe fallback to active review | Add retry/backoff and provider health checks |
+
+## Security assumptions
+
+- Real secrets are provided through environment variables, not committed.
+- Raw incident data is not stored in audit records.
+- The prototype is not used for unattended production closure.
+- Human review remains responsible for final decisions.
+
+## Recommended future controls
+
+1. Add structured configuration validation.
+2. Add provider timeouts and retry/backoff.
+3. Add approval integration with a ticketing or case-management workflow.
+4. Add central audit logging integration.
+5. Add labelled benchmark cases and measurable review metrics.


### PR DESCRIPTION
## Summary

Adds QA, security and operational-readiness documentation to the Sentinel-AI-AutoTriage flagship project.

## Changes

- Adds architecture documentation with Mermaid flow
- Adds threat model
- Adds demo output documentation
- Adds quality and security checklist
- Adds version notes for a v0.1.0-style portfolio release
- Adds Makefile with `make validate`
- Updates CI to run the Makefile validation target

## Quality and security notes

The validation target runs linting, tests with coverage, Bandit review, dependency review and deterministic benchmark generation.