### PR TITLE
Add release readiness docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 All notable changes to **Sentinel-AI-AutoTriage** are documented in this file.
 
-## [Unreleased] - 2026-05-14
+## [Unreleased] - 2026-06-24
+
+### Added
+- Release checklist for creating a GitHub `v0.1.0` release.
+- Version notes and portfolio release guidance.
+- QA, security and operations documentation for employer/client review.
+
+## [Portfolio Hardening] - 2026-05-14
 
 ### Added
 - Deterministic pre-LLM redaction layer for common secret-like, email and IPv4 values.
@@ -16,40 +23,23 @@ All notable changes to **Sentinel-AI-AutoTriage** are documented in this file.
 - Enterprise-provider extension boundary scaffold in `src/azure_provider.py`.
 - Deterministic benchmark dataset in `benchmarks/triage_cases.json`.
 - Benchmark runner and Markdown-summary generation in `src/benchmark.py`.
-- Expanded test suite covering:
-  - LLM JSON parsing and safe fallbacks,
-  - redaction behaviour,
-  - provider injection and deterministic mock completions,
-  - dry-run and explicit mode logic,
-  - recommendation-policy allow/block behaviour,
-  - explicit approval allow/block behaviour,
-  - metadata-only audit record creation and JSONL writing,
-  - non-blocking audit I/O failure handling,
-  - deterministic benchmark behaviour and summary rendering,
-  - Sentinel incident filtering and update handling,
-  - enum and string-form status handling,
-  - required environment configuration,
-  - incident-summary rendering.
+- Expanded test suite covering LLM parsing, redaction, provider injection, dry-run logic, policy checks, approval handling, audit records, benchmark behaviour and Sentinel status handling.
 - `requirements-dev.txt` for CI and local development tooling.
 - `.env.example` with dry-run-safe configuration defaults, optional decision-log path and controlled approval metadata fields.
 - `.gitignore` for local secrets, virtual environments, logs, JSONL audit files, coverage and caches.
 - Complete MIT `LICENSE` file.
 - `samples/sample_incident.json` showing redaction-aware triage input.
-- `docs/technical-walkthrough.md` explaining the hardened architecture and test philosophy.
-- `docs/sample-dry-run-output.md` showing a dry-run transcript with redaction, recommendation checks, approval blocking and zero applied updates.
-- `docs/decision-audit-example.md` showing a metadata-only decision-log example with approval fields.
-- `docs/benchmark-overview.md` explaining deterministic benchmark scope and limits.
-- `docs/deployment-guide.md` describing conservative deployment posture and least-privilege design notes.
-- `docs/provider-extension.md` describing the provider boundary and future enterprise-adapter path.
+- Technical walkthrough, demo output, decision-audit example, benchmark overview, deployment guide and provider-extension notes.
+- Architecture documentation, threat model, quality/security checklist, version notes and Makefile validation target.
 
 ### Changed
 - Refactored incident handling into smaller, testable workflow functions.
 - Hardened status comparison logic so SDK enum and string responses are handled consistently.
 - Simplified runtime dependencies to direct project requirements only.
-- Modernised CI to enforce linting, full tests, coverage reporting and deterministic benchmark generation.
+- Modernised CI to enforce linting, tests, coverage reporting, static review, dependency review and deterministic benchmark generation.
 - Cleaned the Sentinel SDK wrapper and improved defensive handling around missing incident properties.
 - Updated the package exports to expose approval, audit, provider, redaction and recommendation-policy helpers.
-- Refreshed the architecture diagram and README to reflect redaction, recommendation checks, explicit approval, provider abstraction, deterministic benchmarking and the full hardened workflow.
+- Refreshed the README to reflect redaction, recommendation checks, explicit approval, provider abstraction, deterministic benchmarking and the hardened workflow.
 - Updated `SECURITY.md` to document responsible use, recommendation-policy checks, approval state, provider boundary and metadata-only audit safeguards.
 
 ## [0.1.0] - 2026-03-01

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,56 @@
+# Release Checklist
+
+Use this checklist before publishing a GitHub release such as `v0.1.0`.
+
+## Release title
+
+`v0.1.0 - Portfolio Hardening Release`
+
+## Pre-release validation
+
+- [ ] Pull request is merged into `main`.
+- [ ] CI workflow passed.
+- [ ] CodeQL workflow passed.
+- [ ] `make validate` runs successfully.
+- [ ] Benchmark summary is generated successfully.
+- [ ] README links work.
+- [ ] Architecture document is present.
+- [ ] Threat model is present.
+- [ ] Demo output document is present.
+- [ ] Quality and security checklist is present.
+- [ ] Changelog and version notes are present.
+
+## Security review
+
+- [ ] No real API keys, credentials or environment files are included.
+- [ ] Dry-run remains the default documented mode.
+- [ ] Write mode requires explicit configuration.
+- [ ] Sensitive status changes require approval.
+- [ ] Audit records avoid raw incident text and raw prompt content.
+- [ ] Redaction and safe fallback behaviour are covered by tests.
+
+## Suggested release description
+
+```text
+Initial portfolio hardening release of Sentinel-AI-AutoTriage.
+
+This release demonstrates a governed, safety-first AI-assisted Microsoft Sentinel triage workflow with dry-run defaults, data minimisation, deterministic policy gates, explicit approval state, metadata-only audit records, benchmark generation and CI-based validation.
+
+Included:
+- AI-assisted triage workflow
+- Redaction and safe fallback layer
+- Recommendation policy gate
+- Approval state for sensitive status changes
+- Metadata-only audit records
+- Benchmark runner
+- Architecture documentation
+- Threat model
+- Demo output documentation
+- Quality and security checklist
+```
+
+## Post-release actions
+
+- [ ] Add release link to README or portfolio profile.
+- [ ] Mention the release in LinkedIn/GitHub updates.
+- [ ] Add screenshots or exported benchmark output for recruiter review.


### PR DESCRIPTION
## Summary

Adds release-readiness documentation for a future manual GitHub release.

## Changes

- Updates `CHANGELOG.md` with release-readiness notes
- Adds `docs/release-checklist.md`

## Notes

The checklist prepares a future `v0.1.0` portfolio release with validation, security review and suggested release description.